### PR TITLE
allow hide onBlur

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const menubar = require('menubar')({
   height: 410,
   icon: __dirname + '/assets/IconTemplate.png',
   dir: __dirname,
-  alwaysOnTop: true
+  alwaysOnTop: false
 });
 menubar.on('ready', ()=>{
   global.sharedObj = {


### PR DESCRIPTION
Setting `alwaysOnTop` to false (or removing it because false is default) allows user to hide the window when clicking outside of it - without clicking the hide button. This does not change opening the menu window - it stays on top onOpen.
