### PR TITLE
Add a context menu on the app icon on right click for Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+const electron = require('electron');
 const menubar = require('menubar')({
   width: 370,
   height: 410,
@@ -7,11 +8,43 @@ const menubar = require('menubar')({
   tooltip: "Materialette",
   resizable: false
 });
+
+const contextMenu = electron.Menu.buildFromTemplate([
+  {
+    label: 'About',
+    click() {
+      electron.dialog.showMessageBox({title: "Materialette", type:"info", message: "Material Color Palette for macOS, Windows, and Linux", buttons: ["Close"] });
+    }
+  },
+  {
+    label: 'Website',
+    click() {
+      electron.shell.openExternal("https://github.com/mike-schultz/materialette");
+    }
+  },
+  {
+    type: 'separator'
+  },
+  {
+    label: 'Quit',
+    click() {
+      menubar.app.quit();
+    }
+  }
+
+]);
+
 menubar.on('ready', ()=>{
   global.sharedObj = {
     hide: menubar.hideWindow,
     quit: menubar.app.quit,
     pinned: false
+  }
+  
+  // This will add a context menu on the 
+  // app icon on right click for Windows
+  if (process.platform == 'win32') {
+    menubar.tray.setContextMenu(contextMenu);
   }
 });
 


### PR DESCRIPTION
Hello,

Added a context menu on the app icon on right click for Windows. The idea comes from one of my apps [Correo](https://github.com/amitmerchant1990/correo) which I've built last month. Let me know if you face any issues.

It will look something like this:
![context_menu](https://cloud.githubusercontent.com/assets/3647841/19507579/98e6cd70-95f1-11e6-8262-051b39301ce1.jpg)

_Note: This will work only on Windows._

Thanks!
